### PR TITLE
Add option to supply path to OpenSSL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ If you want to see how a completed stack looks, try the demo first.
 
 	-p, --pgp-key        use this PGP key in lieu of creating a new one
 	-k, --tls-key        use this TLS key file in lieu of creating a CA and cert
-	-c, --tls-cert       use this TLS cert file in lieu of creating a CA and cert-
+	-c, --tls-cert       use this TLS cert file in lieu of creating a CA and cert
 	-f, --compose-file   use this Docker Compose manifest
+	-o, --openssl-conf   use this OpenSSL config file
 
 **`setup.sh demo clean`:** Cleans up the demo PGP keys and CA.
 

--- a/setup.sh
+++ b/setup.sh
@@ -68,8 +68,9 @@ setup.sh demo:
 
 	-p, --pgp-key        use this PGP key in lieu of creating a new one
 	-k, --tls-key        use this TLS key file in lieu of creating a CA and cert
-	-c, --tls-cert       use this TLS cert file in lieu of creating a CA and cert-
+	-c, --tls-cert       use this TLS cert file in lieu of creating a CA and cert
 	-f, --compose-file   use this Docker Compose manifest
+	-o, --openssl-conf   use this OpenSSL config file
 
 setup.sh demo clean:
 	Cleans up the demo PGP keys and CA.
@@ -558,6 +559,7 @@ demo() {
             -c | --tls-cert ) tls_cert=$2; shift 2;;
             -a | --ca-cert ) ca_cert=$2; shift 2;;
             -f | --compose-file ) COMPOSE_FILE=$2; shift 2;;
+            -o | --openssl-conf ) openssl_config=$2; shift 2;;
             _ca | check_* | clean | help) cmd=$1; shift 1; $cmd; exit;;
             *) break;;
         esac


### PR DESCRIPTION
``setup.sh demo`` always looks for an OpenSSL config at **/usr/local/etc/openssl/openssl.cnf**:

```
$ ./setup.sh demo
You have not provided a value for --tls-cert or --tls-key. In the next step we
will create a temporary certificate authority in the secrets/ directory and use
it to issue a TLS certificate. The TLS cert and its key will be uploaded to the
Vault instances.

Press any key to continue or Ctrl-C to cancel...

* Creating a certificate authority...
error on line -1 of /usr/local/etc/openssl/openssl.cnf
140736545788936:error:02001002:system library:fopen:No such file or directory:bss_file.c:175:fopen('/usr/local/etc/openssl/openssl.cnf','rb')
140736545788936:error:2006D080:BIO routines:BIO_new_file:no such file:bss_file.c:182:
140736545788936:error:0E078072:configuration file routines:DEF_LOAD:no such file:conf_def.c:195:

$ stat /usr/local/etc/openssl/openssl.cnf
stat: /usr/local/etc/openssl/openssl.cnf: stat: No such file or directory
```

I already had one from pkgsrc in **/opt/pkg/etc/openssl/openssl.cnf** so I added an option to specify the path:

```
$ ./setup.sh demo --openssl-conf /opt/pkg/etc/openssl/openssl.cnf
```

I could just copy or symlink the config to the path in the script, but maybe an option to change this is useful enough to add?